### PR TITLE
fixed appending top movie cards from previous searches

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -207,6 +207,7 @@ $(document).ready(function () {
   getActors();
   // can click on previous actors to search for them again
   $(document).on("click", ".previousActor", function () {
+    $(".topRated").empty();
     personSearch = $(this).text();
     console.log(personSearch);
     retreiveData();


### PR DESCRIPTION
### Previous search bug

Changes:
-Cleared out top movies div when previous searches are clicked, to stop the appending that was happening

